### PR TITLE
Used in-memory cache for alias event and do not unzip every file in one go #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dist
 exports
 test-exports
 migration.conf
+alias.conf

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,12 @@
         "conf": "^10.2.0",
         "fs-extra": "^11.1.0",
         "inquirer": "^9.1.4",
+        "memory-cache": "^0.2.0",
         "node-fetch": "^3.3.0",
         "ora": "^6.1.2"
+      },
+      "bin": {
+        "amplitude-to-posthog": "src/index.js"
       }
     },
     "node_modules/@commander-js/extra-typings": {
@@ -574,6 +578,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
     },
     "node_modules/mimic-fn": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "conf": "^10.2.0",
     "fs-extra": "^11.1.0",
     "inquirer": "^9.1.4",
+    "memory-cache": "^0.2.0",
     "node-fetch": "^3.3.0",
     "ora": "^6.1.2"
   }

--- a/src/alias.js
+++ b/src/alias.js
@@ -1,0 +1,10 @@
+import Conf from 'conf'
+
+const alias = new Conf({
+  configName: 'alias',
+  fileExtension: 'conf',
+  // docs warn against changing `cwd`, but we want to store the config in the app directory
+  cwd: process.cwd(),
+})
+
+export default alias

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 import { program } from '@commander-js/extra-typings';
-import inquirer from 'inquirer'
+import inquirer from 'inquirer';
 
-import config from './config.js'
+import config from './config.js';
+import alias from './alias.js';
 
 // To be used when resuming a halted migration is supported.
 // If a failure occurs at the POSTHOG_IMPORT stage the
@@ -115,7 +116,7 @@ async function checkRequiredConfig() {
 async function setConfig(options) {
   if(options.clearAliases) {
     console.log('Clearing aliases')
-    config.set('mapped_aliases', {})
+    alias.clear()
   }
 
   await checkRequiredConfig()


### PR DESCRIPTION
There are few things that I need to do to run 1 month data backfill with 799410 events.

- Don't unzip every file at the same time.
If I download 1 month data from amplitude, which means that I would have 30*24 gz file I would have to unzip. However, unzip 720 file at the same time would crash the machine for sure. I set it to unzip 24 gz file at one time.

- Move the alias event config to it's own config file for reference. While running in the code, used the in-memory cache to speed up the lookup